### PR TITLE
only create the default admin once

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -3,6 +3,7 @@ includes:
 - layer:nginx
 - layer:apt
 - layer:status
+- layer:leadership
 - interface:pgsql
 repo: https://github.com/tylerscheuble/juju-charm-fresh-rss
 options:

--- a/reactive/fresh_rss.py
+++ b/reactive/fresh_rss.py
@@ -4,10 +4,13 @@ from subprocess import check_call
 from charmhelpers.core import hookenv, unitdata
 from charms.reactive import (
     endpoint_from_flag,
+    is_flag_set,
     when,
     when_not,
     set_flag
 )
+
+import charms.leadership
 
 from charms.layer.nginx import configure_site
 from charms.layer import status
@@ -105,8 +108,12 @@ def install_fresh_rss():
     # ensure the needed directories in ./data/
     run_script('prepare')
     run_script('do-install', install_opts)
-    run_script('create-user', ['--user', config['default-admin-username'],
-                               '--password', config['default-admin-password']])
+
+    if not is_flag_set('leadership.set.default_admin_init'):
+        run_script('create-user',
+            ['--user', config['default-admin-username'],
+             '--password', config['default-admin-password']])
+        charms.leadership.leader_set(default_admin_init="true")
 
     apply_permissions()
 


### PR DESCRIPTION
Use `layer-leadership` to set an init var to the leader so that other non-leaders will not try to create the admin.